### PR TITLE
Check for valid reference for `RSObject.ID`

### DIFF
--- a/Internal/RSObject.simba
+++ b/Internal/RSObject.simba
@@ -117,6 +117,9 @@ end;
 
 Function RSObject.ID: Int32; constref;
 begin
+  if (ref = nil) then
+    exit(-1);
+
   Result := (self.Hash shr 17) and $FFFFFFFF;
 end;
 


### PR DESCRIPTION
`RSObject.ID` would cause the client to crash when `RSObject.ref` was `nil`. This fix checks `RSObject.ref` before attempting to get the ID.